### PR TITLE
Update plotting functions to return figure

### DIFF
--- a/fffit/plot.py
+++ b/fffit/plot.py
@@ -1,9 +1,12 @@
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 
 from fffit.utils import values_scaled_to_real
 from fffit.utils import values_real_to_scaled
 from fffit.utils import variances_scaled_to_real
+
+mpl_is_inline = 'inline' in matplotlib.get_backend()
 
 
 def plot_model_performance(
@@ -25,16 +28,21 @@ def plot_model_performance(
         and dimensionless values
     xylim : array-like, shape=(2,), optional
         lower and upper x and y limits of the plot
-    """
 
+    Returns
+    -------
+    matplotlib.Figure.figure
+    """
     y_data_physical = values_scaled_to_real(y_data, property_bounds)
     min_xylim = np.min(y_data_physical)
     max_xylim = np.max(y_data_physical)
 
+    fig, ax = plt.subplots()
+
     for (label, model) in models.items():
         gp_mu, gp_var = model.predict_f(x_data)
         gp_mu_physical = values_scaled_to_real(gp_mu, property_bounds)
-        plt.scatter(y_data_physical, gp_mu_physical, label=label, zorder=2.5)
+        ax.scatter(y_data_physical, gp_mu_physical, label=label, zorder=2.5)
         meansqerr = np.mean(
             (gp_mu_physical - y_data_physical.reshape(-1, 1)) ** 2
         )
@@ -47,20 +55,22 @@ def plot_model_performance(
     if xylim is None:
         xylim = [min_xylim, max_xylim]
 
-    plt.plot(
+    ax.plot(
         np.arange(xylim[0], xylim[1] + 100, 100),
         np.arange(xylim[0], xylim[1] + 100, 100),
         color="xkcd:blue grey",
         label="y=x",
     )
 
-    plt.xlim(xylim[0], xylim[1])
-    plt.ylim(xylim[0], xylim[1])
-    plt.xlabel("Actual")
-    plt.ylabel("Model Prediction")
-    plt.legend()
-    ax = plt.gca()
+    ax.set_xlim(xylim[0], xylim[1])
+    ax.set_ylim(xylim[0], xylim[1])
+    ax.set_xlabel("Actual")
+    ax.set_ylabel("Model Prediction")
+    ax.legend()
     ax.set_aspect("equal", "box")
+
+    if not mpl_is_inline:
+        return fig
 
 
 def plot_slices_temperature(
@@ -90,6 +100,11 @@ def plot_slices_temperature(
         temperature bounds for the plot
     property_name : str, optional, default="property"
         property name with units for axis label
+
+    Returns
+    -------
+    figs : list
+        list of matplotlib.figure.Figure objects
     """
 
     n_samples = 100
@@ -98,28 +113,33 @@ def plot_slices_temperature(
     )
     vals_scaled = values_real_to_scaled(vals, temperature_bounds)
 
+    figs = []
     for other_vals in np.arange(0, 1.1, 0.1):
         other = np.tile(other_vals, (n_samples, n_params))
         xx = np.hstack((other, vals_scaled))
 
+        fig, ax = plt.subplots()
         for (label, model) in models.items():
             mean_scaled, var_scaled = model.predict_f(xx)
             mean = values_scaled_to_real(mean_scaled, property_bounds)
             var = variances_scaled_to_real(var_scaled, property_bounds)
 
-            plt.plot(vals, mean, lw=2, label=label)
-            plt.fill_between(
+            ax.plot(vals, mean, lw=2, label=label)
+            ax.fill_between(
                 vals[:, 0],
                 mean[:, 0] - 1.96 * np.sqrt(var[:, 0]),
                 mean[:, 0] + 1.96 * np.sqrt(var[:, 0]),
                 alpha=0.3,
             )
 
-        plt.title(f"Other vals = {other_vals:.2f}")
-        plt.xlabel("Temperature")
-        plt.ylabel(property_name)
-        plt.legend()
-        plt.show()
+        ax.set_title(f"Other vals = {other_vals:.2f}")
+        ax.set_xlabel("Temperature")
+        ax.set_ylabel(property_name)
+        fig.legend()
+        figs.append(fig)
+
+    if not mpl_is_inline:
+        return figs
 
 
 def plot_slices_params(
@@ -152,6 +172,11 @@ def plot_slices_params(
         and dimensionless values
     property_name : string, optional, default="property"
         name of property to plot
+
+    Returns
+    -------
+    figs : list
+        list of matplotlib.figure.Figure objects
     """
 
     try:
@@ -168,18 +193,20 @@ def plot_slices_params(
     temp_vals = np.tile(temperature, (n_samples, 1))
     temp_vals_scaled = values_real_to_scaled(temp_vals, temperature_bounds)
 
+    figs = []
     for other_vals in np.arange(0, 1.1, 0.1):
         other1 = np.tile(other_vals, (n_samples, param_idx))
         other2 = np.tile(other_vals, (n_samples, n_params - 1 - param_idx))
         xx = np.hstack((other1, vals_scaled, other2, temp_vals_scaled))
 
+        fig, ax = plt.subplots()
         for (label, model) in models.items():
             mean_scaled, var_scaled = model.predict_f(xx)
             mean = values_scaled_to_real(mean_scaled, property_bounds)
             var = variances_scaled_to_real(var_scaled, property_bounds)
 
-            plt.plot(vals_scaled, mean, lw=2, label=label)
-            plt.fill_between(
+            ax.plot(vals_scaled, mean, lw=2, label=label)
+            ax.fill_between(
                 vals_scaled[:, 0],
                 mean[:, 0] - 1.96 * np.sqrt(var[:, 0]),
                 mean[:, 0] + 1.96 * np.sqrt(var[:, 0]),
@@ -187,13 +214,16 @@ def plot_slices_params(
             )
 
         math_parameter = "$\\" + param_to_plot + "$"
-        plt.title(
+        ax.set_title(
             f"{math_parameter} at T = {temperature:.0f} K. Other vals = {other_vals:.2f}."
         )
-        plt.xlabel(math_parameter)
-        plt.ylabel(property_name)
-        plt.legend()
-        plt.show()
+        ax.set_xlabel(math_parameter)
+        ax.set_ylabel(property_name)
+        fig.legend()
+        figs.append(fig)
+
+    if not mpl_is_inline:
+        return figs
 
 
 def plot_model_vs_test(
@@ -230,6 +260,10 @@ def plot_model_vs_test(
         temperature bounds for the plot
     property_name : str, optional, default="property"
         property name with units for axis label
+
+    Returns
+    -------
+    matplotlib.figure.Figure
     """
 
     n_samples = 100
@@ -241,13 +275,14 @@ def plot_model_vs_test(
     other = np.tile(param_values, (n_samples, 1))
     xx = np.hstack((other, vals_scaled))
 
+    fig, ax = plt.subplots()
     for (label, model) in models.items():
         mean_scaled, var_scaled = model.predict_f(xx)
 
         mean = values_scaled_to_real(mean_scaled, property_bounds)
         var = variances_scaled_to_real(var_scaled, property_bounds)
-        plt.plot(vals, mean, lw=2, label="GP model" + label)
-        plt.fill_between(
+        ax.plot(vals, mean, lw=2, label="GP model" + label)
+        ax.fill_between(
             vals[:, 0],
             mean[:, 0] - 1.96 * np.sqrt(var[:, 0]),
             mean[:, 0] + 1.96 * np.sqrt(var[:, 0]),
@@ -261,7 +296,7 @@ def plot_model_vs_test(
         md_train_property = values_scaled_to_real(
             train_points[:, 1], property_bounds
         )
-        plt.plot(
+        ax.plot(
             md_train_temp, md_train_property, "s", color="black", label="Train"
         )
     if test_points.shape[0] > 0:
@@ -271,9 +306,11 @@ def plot_model_vs_test(
         md_test_property = values_scaled_to_real(
             test_points[:, 1], property_bounds
         )
-        plt.plot(md_test_temp, md_test_property, "ro", label="Test")
+        ax.plot(md_test_temp, md_test_property, "ro", label="Test")
 
-    plt.xlabel("Temperature")
-    plt.ylabel(property_name)
-    plt.legend()
-    plt.show()
+    ax.set_xlabel("Temperature")
+    ax.set_ylabel(property_name)
+    fig.legend()
+
+    if not mpl_is_inline:
+        return fig


### PR DESCRIPTION
Plotting functions now return a `matplotlib.figure.Figure` object (or list thereof) if the backend is _not_ detected as `inline`. 